### PR TITLE
Fix #9

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,10 @@ graphite
 
 Formula to set up and configure graphite servers on Debian and RedHat systems
 
+Set `monitor_master` role grain on the minion you want graphite installed on:
+
+    salt 'graphitemaster' grains.append roles monitor_master
+
 .. note::
 
     See the full `Salt Formulas installation and usage instructions

--- a/graphite/init.sls
+++ b/graphite/init.sls
@@ -1,7 +1,6 @@
+{%- if 'monitor_master' in salt['grains.get']('roles', []) %}
 include:
   - graphite.supervisor
-
-{%- if 'monitor_master' in salt['grains.get']('roles', []) %}
 
 {%- from 'graphite/settings.sls' import graphite with context %}
 

--- a/graphite/supervisor.sls
+++ b/graphite/supervisor.sls
@@ -11,7 +11,9 @@ config-dir:
     - makedirs: True
 
 supervisor:
-  pip.installed
+  pip.installed:
+    - require:
+      - pkg: install-deps
 
 {{ graphite.supervisor_conf }}:
   file.managed:


### PR DESCRIPTION
This formula is currently pretty broken and fails with KeyError if pip isn't installed, despite actually specifying a pip dependency.

In addition, it also tries to install supervisord even if the `monitor_master` role isn't set on the minion which is rather weird and most likely unwanted by most users.

This PR fixes both issues and also mentions the role in the readme.