### PR TITLE
fix django-tagging to 0.3.6

### DIFF
--- a/graphite/files/graphite_reqs.txt
+++ b/graphite/files/graphite_reqs.txt
@@ -1,6 +1,6 @@
 django==1.5
 python-memcached
-django-tagging
+django-tagging==0.3.6
 Twisted==11.1.0
 daemonize
 whisper=={{ graphite_version }}


### PR DESCRIPTION
Fix django-tagging to 0.3.6; fixes #13 
