### PR TITLE
remove MySQL-python package from init.sls

### DIFF
--- a/graphite/init.sls
+++ b/graphite/init.sls
@@ -11,7 +11,6 @@ install-deps:
       - python-pip
       - nginx
       - gcc
-      - MySQL-python
 {%- if grains['os_family'] == 'Debian' %}
       - python-dev
       - sqlite3


### PR DESCRIPTION
Remove the `MySQL-python` package from `init.sls`, which breaks Debian-based installs. This package is already handled by `mysqldb.sls` which handles Debian-based distros correctly, so isn't required here.

Fixes #15 
