### PR TITLE
add daemon package under debian distros

### DIFF
--- a/graphite/init.sls
+++ b/graphite/init.sls
@@ -13,6 +13,7 @@ install-deps:
       - gcc
       - MySQL-python
 {%- if grains['os_family'] == 'Debian' %}
+      - daemon
       - python-dev
       - sqlite3
       - libcairo2


### PR DESCRIPTION
Add `daemon` package to negate the fact that `daemon()` doesn't exist under Debian.

Fixes #14 