### PR TITLE
ensure subsys dir exists before touching lockfile

### DIFF
--- a/graphite/files/supervisor/supervisor.init
+++ b/graphite/files/supervisor/supervisor.init
@@ -23,7 +23,7 @@ start() {
     daemon supervisord
     RETVAL=$?
     echo
-    [ $RETVAL -eq 0 ] && touch /var/lock/subsys/supervisord
+    [ $RETVAL -eq 0 ] && mkdir -p /var/lock/subsys/ && touch /var/lock/subsys/supervisord
 }
 
 stop() {


### PR DESCRIPTION
Ensure `/var/lock/subsys/` exists before attempting to touch the logfile.

Fixes #16 